### PR TITLE
Add image presence validation to Cloth model

### DIFF
--- a/app/models/cloth.rb
+++ b/app/models/cloth.rb
@@ -7,6 +7,7 @@ class Cloth < ApplicationRecord
 
     validates :user_id, presence: true
     validates :last_worn_on, presence: true
+    validates :image, presence: true  # ここに追加    
     validate :last_worn_on_is_date?
 
     private


### PR DESCRIPTION
  This PR adds a validation rule to the Cloth model to ensure that an image is always attached when a new cloth is registered.

  Changes:
  - Added `validates :image, presence: true` to the Cloth model.

  This change will prevent clothes from being registered without an image.